### PR TITLE
Removing Giant stacktrace when building offline.

### DIFF
--- a/publishers/gradle-plugin/src/main/groovy/projektor/plugin/results/grouped/GroupedResults.groovy
+++ b/publishers/gradle-plugin/src/main/groovy/projektor/plugin/results/grouped/GroupedResults.groovy
@@ -1,5 +1,5 @@
 package projektor.plugin.results.grouped;
 
 class GroupedResults {
-    public List<GroupedTestSuites> groupedTestSuites
+    public List<GroupedTestSuites> groupedTestSuites = []
 }

--- a/publishers/gradle-plugin/src/test/groovy/projektor/plugin/results/ResultsClientSpec.groovy
+++ b/publishers/gradle-plugin/src/test/groovy/projektor/plugin/results/ResultsClientSpec.groovy
@@ -91,4 +91,22 @@ class ResultsClientSpec extends Specification {
         HttpHeader publishTokenInHeader = resultsRequest.header(ClientToken.PUBLISH_TOKEN_NAME)
         publishTokenInHeader.firstValue() == "token12345"
     }
+
+    void "should not stacktrace when offline"() {
+        given:
+        String serverUrl = "http://resolve.failure.fakedotcom:9999/womp"
+        ResultsClient resultsClient = new ResultsClient(
+                okHttpClient,
+                new ClientConfig(serverUrl, Optional.empty()),
+                logger
+        )
+        GroupedResults groupedResults = new GroupedResults()
+
+        when:
+        PublishResult publishResult = resultsClient.sendResultsToServer(groupedResults)
+
+        then:
+        !publishResult.successful
+
+    }
 }


### PR DESCRIPTION
Ensuring there isn't a large stacktrace when building projects offline
or when not on a VPN when required.