### PR TITLE
(feature) In failed test panel, only collapse on click of test case name in summary so it's easier to select and copy the test case failure

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -40,7 +40,8 @@
     "rimraf": "3.0.2",
     "start-server-and-test": "1.10.11",
     "ts-jest": "27.0.3",
-    "typescript": "4.3.4"
+    "typescript": "4.3.4",
+    "wait-for-expect": "3.0.2"
   },
   "dependencies": {
     "@material-ui/core": "4.9.14",

--- a/ui/src/TestCase/TestCaseFailurePanel.tsx
+++ b/ui/src/TestCase/TestCaseFailurePanel.tsx
@@ -67,12 +67,13 @@ const TestCaseFailurePanel = ({
   return (
     <ExpansionPanel
       expanded={expanded}
-      onClick={expansionPanelOnClick}
       data-testid={`test-case-summary-${testCaseIdentifier}`}
     >
       <ExpansionPanelSummary
         expandIcon={<ExpandMoreIcon />}
         style={{ userSelect: "text" }}
+        onClick={expansionPanelOnClick}
+        data-testid={`test-case-summary-header-${testCaseIdentifier}`}
       >
         <Typography variant="subtitle2" data-testid="test-case-title">
           {testCase.packageName}.{testCase.className} {testCase.name}

--- a/ui/src/TestCase/__tests__/TestCaseFailurePanel.spec.tsx
+++ b/ui/src/TestCase/__tests__/TestCaseFailurePanel.spec.tsx
@@ -7,8 +7,9 @@ import {
   TestCase,
   TestFailure,
 } from "../../model/TestRunModel";
-import TestCaseFailurePanel from "../TestCaseFailurePanel";
 import moment from "moment";
+import waitForExpect from "wait-for-expect";
+import TestCaseFailurePanel from "../TestCaseFailurePanel";
 
 describe("TestCaseFailurePanel", () => {
   it("should render failure details link when the test case failed", () => {
@@ -210,6 +211,58 @@ describe("TestCaseFailurePanel", () => {
 
     expect(getByTestId("test-case-failure-text-2-1")).toHaveTextContent(
       "My failure text"
+    );
+  });
+
+  it("should collapse panel when clicking on test case title", async () => {
+    const failure: TestFailure = {
+      failureMessage: "My failure message",
+      failureText: "My failure text",
+      failureType: "",
+    };
+
+    const testCase = createTestCaseWithFailure(failure);
+
+    const { getByTestId } = render(
+      <TestCaseFailurePanel
+        testCase={testCase}
+        publicId="12345"
+        showFullFailure={true}
+      />
+    );
+
+    getByTestId("test-case-summary-header-2-1").click();
+
+    await waitForExpect(() =>
+      expect(getByTestId("test-case-summary-header-2-1")).toHaveAttribute(
+        "aria-expanded",
+        "false"
+      )
+    );
+  });
+
+  it("should not collapse panel when clicking on failure body text", () => {
+    const failure: TestFailure = {
+      failureMessage: "My failure message",
+      failureText: "My failure text",
+      failureType: "",
+    };
+
+    const testCase = createTestCaseWithFailure(failure);
+
+    const { getByTestId } = render(
+      <TestCaseFailurePanel
+        testCase={testCase}
+        publicId="12345"
+        showFullFailure={true}
+      />
+    );
+
+    getByTestId("test-case-failure-text-2-1").click();
+
+    expect(getByTestId("test-case-summary-header-2-1")).toHaveAttribute(
+      "aria-expanded",
+      "true"
     );
   });
 

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -8766,6 +8766,11 @@ w3c-xmlserializer@^2.0.0:
   dependencies:
     xml-name-validator "^3.0.0"
 
+wait-for-expect@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-3.0.2.tgz#d2f14b2f7b778c9b82144109c8fa89ceaadaa463"
+  integrity sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==
+
 wait-on@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-4.0.0.tgz#4d7e4485ca759968897fd3b0cc50720c0b4ca959"


### PR DESCRIPTION
Fixes #426