### PR TITLE
(chore) Gradle plugin: Use non-deprecated report properties when available

### DIFF
--- a/publishers/gradle-plugin/build.gradle
+++ b/publishers/gradle-plugin/build.gradle
@@ -44,7 +44,7 @@ repositories {
 }
 
 group = "dev.projektor"
-version = "7.5.2"
+version = "7.6.0"
 
 dependencies {
     implementation("com.squareup.okhttp3:okhttp:4.2.1")

--- a/publishers/gradle-plugin/src/main/groovy/projektor/plugin/TestTaskGroup.groovy
+++ b/publishers/gradle-plugin/src/main/groovy/projektor/plugin/TestTaskGroup.groovy
@@ -16,7 +16,13 @@ class TestTaskGroup implements TestGroup {
 
     @Override
     File getResultsDir() {
-        return task.reports.junitXml.destination
+        // Report.destination is going to be replaced with Report.outputLocation in Gradle 8.0,
+        // so use Report.outputLocation if it is available
+        if (task.reports.junitXml.hasProperty("outputLocation")) {
+            return task.reports.junitXml.outputLocation.asFile.get()
+        } else {
+            return task.reports.junitXml.destination
+        }
     }
 
     @Override

--- a/publishers/gradle-plugin/src/main/groovy/projektor/plugin/coverage/CodeCoverageTaskCollector.groovy
+++ b/publishers/gradle-plugin/src/main/groovy/projektor/plugin/coverage/CodeCoverageTaskCollector.groovy
@@ -43,9 +43,7 @@ class CodeCoverageTaskCollector {
     }
 
     private CodeCoverageFile coverageFileOrNull(JacocoReport reportTask) {
-        SingleFileReport xmlReport = reportTask.reports.xml
-
-        File xmlReportFile = xmlReport.destination
+        File xmlReportFile = extractReportFile(reportTask)
 
         if (xmlReportFile.exists()) {
             String baseDirectoryPath = findBaseDirectoryPath(reportTask)
@@ -57,6 +55,18 @@ class CodeCoverageTaskCollector {
             logger.info("Projektor found no XML report for Jacoco task ${reportTask.name} in project ${reportTask.project.name}")
 
             return null
+        }
+    }
+
+    private static File extractReportFile(JacocoReport reportTask) {
+        SingleFileReport xmlReport = reportTask.reports.xml
+
+        // Report.destination is going to be replaced with Report.outputLocation in Gradle 8.0,
+        // so use Report.outputLocation if it is available
+        if (xmlReport.hasProperty("outputLocation")) {
+            return xmlReport.outputLocation.asFile.get()
+        } else {
+            return xmlReport.destination
         }
     }
 

--- a/publishers/gradle-plugin/src/main/groovy/projektor/plugin/coverage/CodeCoverageTaskConfigurator.groovy
+++ b/publishers/gradle-plugin/src/main/groovy/projektor/plugin/coverage/CodeCoverageTaskConfigurator.groovy
@@ -16,7 +16,15 @@ class CodeCoverageTaskConfigurator {
             jacocoTestReportTasks.each { task ->
                 if (task instanceof JacocoReport) {
                     logger.info("Projektor enabling XML report for task ${task.name} in project ${project.name}")
-                    task.reports.xml.enabled = true
+
+                    // Report.enabled is going to be replaced with Report.required in Gradle 8.0,
+                    // so use Report.required if it is available
+                    if (task.reports.xml.hasProperty("required")) {
+                        task.reports.xml.required = true
+                    } else {
+                        task.reports.xml.enabled = true
+                    }
+
                 }
             }
         }

--- a/publishers/gradle-plugin/src/test/groovy/projektor/plugin/testkit/version/CoverageGradleVersionSingleProjectSpec.groovy
+++ b/publishers/gradle-plugin/src/test/groovy/projektor/plugin/testkit/version/CoverageGradleVersionSingleProjectSpec.groovy
@@ -25,6 +25,7 @@ class CoverageGradleVersionSingleProjectSpec extends SingleProjectSpec {
         buildFile << """
             projektor {
                 serverUrl = '${serverUrl}'
+                alwaysPublish = true
             }
         """.stripIndent()
 
@@ -41,7 +42,7 @@ class CoverageGradleVersionSingleProjectSpec extends SingleProjectSpec {
         def result = runSuccessfulBuildWithEnvironmentAndGradleVersion(
                 ["CI": "true"],
                 gradleVersion,
-                'test', 'jacocoTestReport', '--info'
+                'test', 'jacocoTestReport', '--info', '--warning-mode', 'all'
         )
 
         then:
@@ -50,6 +51,9 @@ class CoverageGradleVersionSingleProjectSpec extends SingleProjectSpec {
 
         and:
         verifyOutputContainsReportLink(result.output, serverUrl, resultsId)
+
+        and:
+        !result.output.contains("scheduled to be removed in Gradle 8.0")
 
         and:
         List<GroupedResults> resultsRequestBodies = resultsStubber.findResultsRequestBodies()
@@ -67,6 +71,7 @@ class CoverageGradleVersionSingleProjectSpec extends SingleProjectSpec {
         GradleVersion.version("6.0.1") | _
         GradleVersion.version("6.4.1") | _
         GradleVersion.version("7.0")   | _
+        GradleVersion.version("7.2")   | _
         GradleVersion.current()        | _
     }
 }

--- a/publishers/gradle-plugin/src/test/groovy/projektor/plugin/testkit/version/ResultsGradleVersionSingleProjectSpec.groovy
+++ b/publishers/gradle-plugin/src/test/groovy/projektor/plugin/testkit/version/ResultsGradleVersionSingleProjectSpec.groovy
@@ -45,6 +45,7 @@ class ResultsGradleVersionSingleProjectSpec extends SingleProjectSpec {
         "6.0.1"                         | _
         "6.4.1"                         | _
         "7.0"                           | _
+        "7.2"                           | _
         GradleVersion.current().version | _
     }
 }


### PR DESCRIPTION
Fixes #434 