### PR TITLE
feat: Add support for kover code coverage reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ https://projektorlive.herokuapp.com/tests/V1BMYK93MTNR/suite/65/systemOut
 ## Code coverage stats
 
 Projektor can capture and visualize code coverage stats from any project that can output code coverage data in 
-Jacoco (Gradle, sbt, etc.), Clover (Jest, Cypress, etc.), and Cobertura formats.
+Jacoco (Gradle, sbt, etc.), Kover, Clover (Jest, Cypress, etc.), and Cobertura formats.
 
 Projektor calculates overall code coverage stats for the project as well as per-module coverage breakdowns
 for Gradle multi-project builds:

--- a/publishers/gradle-plugin/src/functionalTest/groovy/projektor/plugin/functionaltest/MultiProjectFunctionalSpecification.groovy
+++ b/publishers/gradle-plugin/src/functionalTest/groovy/projektor/plugin/functionaltest/MultiProjectFunctionalSpecification.groovy
@@ -36,9 +36,9 @@ include 'project1', 'project2', 'project3'
 
         rootBuildFile = BuildFileWriter.createRootBuildFile(projectRootDir)
 
-        BuildFileWriter.writeBuildFileContents(buildFileProject1, false, includeJacocoPlugin())
-        BuildFileWriter.writeBuildFileContents(buildFileProject2, false, includeJacocoPlugin())
-        BuildFileWriter.writeBuildFileContents(buildFileProject3, false, includeJacocoPlugin())
+        BuildFileWriter.writeBuildFileContents(buildFileProject1, false, includeJacocoPlugin(), includeKoverPlugin())
+        BuildFileWriter.writeBuildFileContents(buildFileProject2, false, includeJacocoPlugin(), includeKoverPlugin())
+        BuildFileWriter.writeBuildFileContents(buildFileProject3, false, includeJacocoPlugin(), includeKoverPlugin())
 
         testDirectory1 = createTestDirectory(projectDir1)
         testDirectory2 = createTestDirectory(projectDir2)
@@ -46,6 +46,10 @@ include 'project1', 'project2', 'project3'
     }
 
     boolean includeJacocoPlugin() {
+        return false
+    }
+
+    boolean includeKoverPlugin() {
         return false
     }
 }

--- a/publishers/gradle-plugin/src/test/groovy/projektor/plugin/testkit/MultiProjectSpec.groovy
+++ b/publishers/gradle-plugin/src/test/groovy/projektor/plugin/testkit/MultiProjectSpec.groovy
@@ -36,9 +36,9 @@ include 'project1', 'project2', 'project3'
 
         rootBuildFile = BuildFileWriter.createRootBuildFile(projectRootDir)
 
-        BuildFileWriter.writeBuildFileContents(buildFileProject1, false, includeJacocoPlugin(), includeCodenarcPlugin())
-        BuildFileWriter.writeBuildFileContents(buildFileProject2, false, includeJacocoPlugin(), includeCodenarcPlugin())
-        BuildFileWriter.writeBuildFileContents(buildFileProject3, false, includeJacocoPlugin(), includeCodenarcPlugin())
+        BuildFileWriter.writeBuildFileContents(buildFileProject1, false, includeJacocoPlugin(), includeKoverPlugin(), includeCodenarcPlugin())
+        BuildFileWriter.writeBuildFileContents(buildFileProject2, false, includeJacocoPlugin(), includeKoverPlugin(), includeCodenarcPlugin())
+        BuildFileWriter.writeBuildFileContents(buildFileProject3, false, includeJacocoPlugin(), includeKoverPlugin(), includeCodenarcPlugin())
 
         testDirectory1 = createTestDirectory(projectDir1)
         testDirectory2 = createTestDirectory(projectDir2)

--- a/publishers/gradle-plugin/src/test/groovy/projektor/plugin/testkit/ProjectSpec.groovy
+++ b/publishers/gradle-plugin/src/test/groovy/projektor/plugin/testkit/ProjectSpec.groovy
@@ -98,6 +98,10 @@ abstract class ProjectSpec extends Specification {
         return false
     }
 
+    boolean includeKoverPlugin() {
+        return false
+    }
+
     boolean includeCodenarcPlugin() {
         return false
     }

--- a/publishers/gradle-plugin/src/test/groovy/projektor/plugin/testkit/SingleProjectSpec.groovy
+++ b/publishers/gradle-plugin/src/test/groovy/projektor/plugin/testkit/SingleProjectSpec.groovy
@@ -10,6 +10,7 @@ abstract class SingleProjectSpec extends ProjectSpec {
                 projectRootDir,
                 true,
                 includeJacocoPlugin(),
+                includeKoverPlugin(),
                 includeCodenarcPlugin()
         )
     }

--- a/publishers/gradle-plugin/src/test/groovy/projektor/plugin/testkit/coverage/KoverCoverageAutoPublishInCISpec.groovy
+++ b/publishers/gradle-plugin/src/test/groovy/projektor/plugin/testkit/coverage/KoverCoverageAutoPublishInCISpec.groovy
@@ -1,0 +1,77 @@
+package projektor.plugin.testkit.coverage
+
+import projektor.plugin.results.grouped.GroupedResults
+import projektor.plugin.testkit.SingleProjectSpec
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import static projektor.plugin.CodeUnderTestWriter.writePartialCoverageSpecFile
+import static projektor.plugin.CodeUnderTestWriter.writeSourceCodeFile
+import static projektor.plugin.ProjectDirectoryWriter.createSourceDirectory
+import static projektor.plugin.ProjectDirectoryWriter.createTestDirectory
+
+class KoverCoverageAutoPublishInCISpec extends SingleProjectSpec {
+    @Override
+    boolean includeKoverPlugin() {
+        return true
+    }
+
+    def "should publish results and coverage when publish in CI enabled and coverage exists"() {
+        given:
+        buildFile << """
+            projektor {
+                serverUrl = '${serverUrl}'
+            }
+        """.stripIndent()
+
+        String publicId = "AUTOCOV123"
+        resultsStubber.stubResultsPostSuccess(publicId)
+
+        File sourceDir = createSourceDirectory(projectRootDir)
+        File testDir = createTestDirectory(projectRootDir)
+
+        writeSourceCodeFile(sourceDir)
+        writePartialCoverageSpecFile(testDir, "PartialSpec")
+
+        when:
+        def result = runSuccessfulBuildWithEnvironment(["CI": "true"], 'test', 'koverXmlReport')
+
+        then:
+        result.task(":test").outcome == SUCCESS
+        result.task(":koverXmlReport").outcome == SUCCESS
+
+        and:
+        List<GroupedResults> resultRequestBodies = resultsStubber.findResultsRequestBodies()
+        resultRequestBodies.size() == 1
+
+        resultRequestBodies[0].coverageFiles.size() == 1
+    }
+
+    def "should not publish results and coverage when local and running non-test task"() {
+        given:
+        buildFile << """
+            projektor {
+                serverUrl = '${serverUrl}'
+            }
+        """.stripIndent()
+
+        String publicId = "AUTOCOV123"
+        resultsStubber.stubResultsPostSuccess(publicId)
+
+        File sourceDir = createSourceDirectory(projectRootDir)
+        File testDir = createTestDirectory(projectRootDir)
+
+        writeSourceCodeFile(sourceDir)
+        writePartialCoverageSpecFile(testDir, "PartialSpec")
+
+        when:
+        def result = runSuccessfulLocalBuild('tasks')
+
+        then:
+        result.task(":tasks").outcome == SUCCESS
+        !result.task(":koverXmlReport")
+        !result.task(":test")
+
+        and:
+        resultsStubber.findResultsRequests().size() == 0
+    }
+}

--- a/publishers/gradle-plugin/src/test/groovy/projektor/plugin/testkit/coverage/KoverCoverageMultiProjectSpec.groovy
+++ b/publishers/gradle-plugin/src/test/groovy/projektor/plugin/testkit/coverage/KoverCoverageMultiProjectSpec.groovy
@@ -1,0 +1,252 @@
+package projektor.plugin.testkit.coverage
+
+import projektor.plugin.coverage.model.CoverageFilePayload
+import projektor.plugin.results.grouped.GroupedResults
+import projektor.plugin.testkit.MultiProjectSpec
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import static org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE
+import static projektor.plugin.CodeUnderTestWriter.writePartialCoverageSpecFile
+import static projektor.plugin.CodeUnderTestWriter.writeSourceCodeFile
+import static projektor.plugin.ProjectDirectoryWriter.createSourceDirectory
+
+class KoverCoverageMultiProjectSpec extends MultiProjectSpec {
+    File sourceDirectory1
+    File sourceDirectory2
+    File sourceDirectory3
+
+    @Override
+    boolean includeKoverPlugin() {
+        return true
+    }
+
+    def setup() {
+        sourceDirectory1 = createSourceDirectory(projectDir1)
+        sourceDirectory2 = createSourceDirectory(projectDir2)
+        sourceDirectory3 = createSourceDirectory(projectDir3)
+    }
+
+    def "should publish coverage from multi-project build to server"() {
+        given:
+        rootBuildFile << """
+            projektor {
+                serverUrl = '${serverUrl}'
+                alwaysPublishInCI = true
+            }
+        """.stripIndent()
+
+        String publicId = "COV123"
+        resultsStubber.stubResultsPostSuccess(publicId)
+
+        writeSourceCodeFile(sourceDirectory1)
+        writePartialCoverageSpecFile(testDirectory1, "PartialSpec1")
+
+        writeSourceCodeFile(sourceDirectory2)
+        writePartialCoverageSpecFile(testDirectory2, "PartialSpec2")
+
+        writeSourceCodeFile(sourceDirectory3)
+        writePartialCoverageSpecFile(testDirectory3, "PartialSpec3")
+
+        when:
+        def result = runSuccessfulBuildInCI('test', 'koverXmlReport', '-i')
+
+        then:
+        result.task(":project1:test").outcome == SUCCESS
+        result.task(":project1:koverXmlReport").outcome == SUCCESS
+
+        result.task(":project2:test").outcome == SUCCESS
+        result.task(":project2:koverXmlReport").outcome == SUCCESS
+
+        result.task(":project3:test").outcome == SUCCESS
+        result.task(":project3:koverXmlReport").outcome == SUCCESS
+
+        and:
+        List<GroupedResults> resultsRequestBodies = resultsStubber.findResultsRequestBodies()
+        resultsRequestBodies.size() == 1
+
+        List<CoverageFilePayload> coverageFilePayloads = resultsRequestBodies[0].coverageFiles
+        coverageFilePayloads.size() == 3
+    }
+
+    def "should include full directory path in published coverage data"() {
+        given:
+        rootBuildFile << """
+            projektor {
+                serverUrl = '${serverUrl}'
+                alwaysPublishInCI = true
+            }
+        """.stripIndent()
+
+        String publicId = "COV123"
+        resultsStubber.stubResultsPostSuccess(publicId)
+
+        writeSourceCodeFile(sourceDirectory1)
+        writePartialCoverageSpecFile(testDirectory1, "PartialSpec1")
+
+        writeSourceCodeFile(sourceDirectory2)
+        writePartialCoverageSpecFile(testDirectory2, "PartialSpec2")
+
+        writeSourceCodeFile(sourceDirectory3)
+        writePartialCoverageSpecFile(testDirectory3, "PartialSpec3")
+
+        when:
+        def result = runSuccessfulBuildInCI('test', 'koverXmlReport', '-i')
+
+        then:
+        result.task(":project1:test").outcome == SUCCESS
+        result.task(":project1:koverXmlReport").outcome == SUCCESS
+
+        result.task(":project2:test").outcome == SUCCESS
+        result.task(":project2:koverXmlReport").outcome == SUCCESS
+
+        result.task(":project3:test").outcome == SUCCESS
+        result.task(":project3:koverXmlReport").outcome == SUCCESS
+
+        and:
+        List<GroupedResults> resultsRequestBodies = resultsStubber.findResultsRequestBodies()
+        resultsRequestBodies.size() == 1
+
+        List<CoverageFilePayload> coverageFilePayloads = resultsRequestBodies[0].coverageFiles
+        coverageFilePayloads.size() == 3
+
+        coverageFilePayloads.find { it.baseDirectoryPath.contains("project1/build/classes/groovy/main")}
+        coverageFilePayloads.find { it.baseDirectoryPath.contains("project2/build/classes/groovy/main")}
+        coverageFilePayloads.find { it.baseDirectoryPath.contains("project3/build/classes/groovy/main")}
+    }
+
+    def "when only one subproject changes should publish coverage from all subprojects"() {
+        given:
+        rootBuildFile << """
+            projektor {
+                serverUrl = '${serverUrl}'
+                alwaysPublishInCI = true
+            }
+        """.stripIndent()
+
+        String publicId1 = "COVER1"
+        resultsStubber.stubResultsPostSuccess(publicId1)
+
+        writeSourceCodeFile(sourceDirectory1)
+        writePartialCoverageSpecFile(testDirectory1, "PartialSpec1")
+
+        writeSourceCodeFile(sourceDirectory2)
+        writePartialCoverageSpecFile(testDirectory2, "PartialSpec2")
+
+        writeSourceCodeFile(sourceDirectory3)
+        writePartialCoverageSpecFile(testDirectory3, "PartialSpec3")
+
+        when:
+        def result1 = runSuccessfulBuildInCI('test', 'koverXmlReport', '-i')
+
+        then:
+        result1.task(":project1:test").outcome == SUCCESS
+        result1.task(":project1:koverXmlReport").outcome == SUCCESS
+
+        result1.task(":project2:test").outcome == SUCCESS
+        result1.task(":project2:koverXmlReport").outcome == SUCCESS
+
+        result1.task(":project3:test").outcome == SUCCESS
+        result1.task(":project3:koverXmlReport").outcome == SUCCESS
+
+        and:
+        List<GroupedResults> resultsRequestBodies1 = resultsStubber.findResultsRequestBodies()
+        resultsRequestBodies1.size() == 1
+
+        List<CoverageFilePayload> coverageFilePayloads1 = resultsRequestBodies1[0].coverageFiles
+        coverageFilePayloads1.size() == 3
+
+        when:
+        wireMockRule.resetAll()
+
+        String publicId2 = "COVER2"
+        resultsStubber.stubResultsPostSuccess(publicId2)
+
+        writePartialCoverageSpecFile(testDirectory2, "PartialSpec4")
+
+        def result2 = runSuccessfulBuildInCI('test', 'koverXmlReport', '-i')
+
+        then:
+        result2.task(":project1:test").outcome == UP_TO_DATE
+        result2.task(":project1:koverXmlReport").outcome == UP_TO_DATE
+
+        result2.task(":project2:test").outcome == SUCCESS
+        result2.task(":project2:koverXmlReport").outcome == SUCCESS
+
+        result2.task(":project3:test").outcome == UP_TO_DATE
+        result2.task(":project3:koverXmlReport").outcome == UP_TO_DATE
+
+        and:
+        List<GroupedResults> resultsRequestBodies2 = resultsStubber.findResultsRequestBodies()
+        resultsRequestBodies2.size() == 1
+
+        List<CoverageFilePayload> coverageFilePayloads2 = resultsRequestBodies2[0].coverageFiles
+        coverageFilePayloads2.size() == 3
+    }
+
+    def "when no subprojects change and in CI should publish coverage from all subprojects"() {
+        given:
+        rootBuildFile << """
+            projektor {
+                serverUrl = '${serverUrl}'
+                alwaysPublishInCI = true
+            }
+        """.stripIndent()
+
+        String publicId1 = "COVER1"
+        resultsStubber.stubResultsPostSuccess(publicId1)
+
+        writeSourceCodeFile(sourceDirectory1)
+        writePartialCoverageSpecFile(testDirectory1, "PartialSpec1")
+
+        writeSourceCodeFile(sourceDirectory2)
+        writePartialCoverageSpecFile(testDirectory2, "PartialSpec2")
+
+        writeSourceCodeFile(sourceDirectory3)
+        writePartialCoverageSpecFile(testDirectory3, "PartialSpec3")
+
+        when:
+        def result1 = runSuccessfulBuildWithEnvironment(["CI": "true"], 'test', 'koverXmlReport')
+
+        then:
+        result1.task(":project1:test").outcome == SUCCESS
+        result1.task(":project1:koverXmlReport").outcome == SUCCESS
+
+        result1.task(":project2:test").outcome == SUCCESS
+        result1.task(":project2:koverXmlReport").outcome == SUCCESS
+
+        result1.task(":project3:test").outcome == SUCCESS
+        result1.task(":project3:koverXmlReport").outcome == SUCCESS
+
+        and:
+        List<GroupedResults> resultsRequestBodies1 = resultsStubber.findResultsRequestBodies()
+        resultsRequestBodies1.size() == 1
+
+        List<CoverageFilePayload> coverageFilePayloads1 = resultsRequestBodies1[0].coverageFiles
+        coverageFilePayloads1.size() == 3
+
+        when:
+        wireMockRule.resetAll()
+
+        String publicId2 = "COVER2"
+        resultsStubber.stubResultsPostSuccess(publicId2)
+
+        def result2 = runSuccessfulBuildWithEnvironment(["CI": "true"], 'test', 'koverXmlReport', '-i')
+
+        then:
+        result2.task(":project1:test").outcome == UP_TO_DATE
+        result2.task(":project1:koverXmlReport").outcome == UP_TO_DATE
+
+        result2.task(":project2:test").outcome == UP_TO_DATE
+        result2.task(":project2:koverXmlReport").outcome == UP_TO_DATE
+
+        result2.task(":project3:test").outcome == UP_TO_DATE
+        result2.task(":project3:koverXmlReport").outcome == UP_TO_DATE
+
+        and:
+        List<GroupedResults> resultsRequestBodies2 = resultsStubber.findResultsRequestBodies()
+        resultsRequestBodies2.size() == 1
+
+        List<CoverageFilePayload> coverageFilePayloads2 = resultsRequestBodies2[0].coverageFiles
+        coverageFilePayloads2.size() == 3
+    }
+}

--- a/publishers/gradle-plugin/src/test/groovy/projektor/plugin/testkit/coverage/KoverCoverageMultiTaskSpec.groovy
+++ b/publishers/gradle-plugin/src/test/groovy/projektor/plugin/testkit/coverage/KoverCoverageMultiTaskSpec.groovy
@@ -1,0 +1,106 @@
+package projektor.plugin.testkit.coverage
+
+import org.gradle.util.GradleVersion
+import projektor.plugin.coverage.model.CoverageFilePayload
+import projektor.plugin.results.grouped.GroupedResults
+import projektor.plugin.testkit.SingleProjectSpec
+import spock.lang.See
+import spock.lang.Unroll
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import static projektor.plugin.CodeUnderTestWriter.writePartialCoverageSpecFile
+import static projektor.plugin.CodeUnderTestWriter.writeSecondPartialCoverageSpecFile
+import static projektor.plugin.CodeUnderTestWriter.writeSourceCodeFile
+import static projektor.plugin.ProjectDirectoryWriter.createIntegrationTestDirectory
+import static projektor.plugin.ProjectDirectoryWriter.createSourceDirectory
+import static projektor.plugin.ProjectDirectoryWriter.createTestDirectory
+
+class KoverCoverageMultiTaskSpec extends SingleProjectSpec {
+
+    @Override
+    boolean includeKoverPlugin() {
+        return true
+    }
+
+    @See("https://github.com/Kotlin/kotlinx-kover - Minimal supported Gradle version: 6.4")
+    @Unroll
+    def "should publish coverage results from unit and integration tests to server with Gradle version #gradleVersion"() {
+        given:
+        buildFile << """
+            sourceSets {
+                intTest {
+                    compileClasspath += sourceSets.main.output
+                    runtimeClasspath += sourceSets.main.output
+                }
+            }
+            
+            configurations {
+                intTestImplementation.extendsFrom testImplementation
+                intTestRuntimeOnly.extendsFrom runtimeOnly
+            }
+
+            task integrationTest(type: Test) {
+                description = 'Runs integration tests.'
+                group = 'verification'
+            
+                testClassesDirs = sourceSets.intTest.output.classesDirs
+                classpath = sourceSets.intTest.runtimeClasspath
+            }
+
+            kover {
+              coverageEngine.set(kotlinx.kover.api.CoverageEngine.JACOCO)
+            }
+
+            integrationTest {
+                kover {
+                    enabled = true
+                }
+            }
+
+            projektor {
+                serverUrl = '${serverUrl}'
+            }
+        """.stripIndent()
+
+        String publicId = "COV123"
+        resultsStubber.stubResultsPostSuccess(publicId)
+
+        File sourceDir = createSourceDirectory(projectRootDir)
+        File testDir = createTestDirectory(projectRootDir)
+        File integrationTestDir = createIntegrationTestDirectory(projectRootDir)
+
+        writeSourceCodeFile(sourceDir)
+        writePartialCoverageSpecFile(testDir, "PartialSpec")
+        writeSecondPartialCoverageSpecFile(integrationTestDir, "PartialIntegrationSpec")
+
+        when:
+        def result = runSuccessfulBuildWithEnvironmentAndGradleVersion(
+                ["CI": "true"],
+                gradleVersion,
+                'test', 'koverXmlReport', '-i'
+        )
+
+        then:
+        result.task(":test").outcome == SUCCESS
+        result.task(":integrationTest").outcome == SUCCESS
+        result.task(":koverXmlReport").outcome == SUCCESS
+        result.task(":koverXmlReport").outcome == SUCCESS
+
+        and:
+        List<GroupedResults> resultsRequestBodies = resultsStubber.findResultsRequestBodies()
+        resultsRequestBodies.size() == 1
+
+        List<CoverageFilePayload> coverageFilePayloads = resultsRequestBodies[0].coverageFiles
+        coverageFilePayloads.size() == 1
+
+        coverageFilePayloads[0].reportContents.contains("MyClass")
+        coverageFilePayloads[0].reportContents.contains('<counter type="LINE" missed="0" covered="2"/>')
+
+        where:
+        gradleVersion                  | _
+        GradleVersion.version("6.0.1") | _
+        GradleVersion.version("6.4.1") | _
+        GradleVersion.version("7.0")   | _
+        GradleVersion.current()        | _
+    }
+}

--- a/publishers/gradle-plugin/src/test/groovy/projektor/plugin/testkit/coverage/KoverCoverageSingleProjectSpec.groovy
+++ b/publishers/gradle-plugin/src/test/groovy/projektor/plugin/testkit/coverage/KoverCoverageSingleProjectSpec.groovy
@@ -1,0 +1,107 @@
+package projektor.plugin.testkit.coverage
+
+import projektor.plugin.coverage.model.CoverageFilePayload
+import projektor.plugin.results.grouped.GroupedResults
+import projektor.plugin.testkit.SingleProjectSpec
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import static projektor.plugin.CodeUnderTestWriter.writePartialCoverageSpecFile
+import static projektor.plugin.CodeUnderTestWriter.writeSourceCodeFile
+import static projektor.plugin.ProjectDirectoryWriter.createSourceDirectory
+import static projektor.plugin.ProjectDirectoryWriter.createTestDirectory
+
+class KoverCoverageSingleProjectSpec extends SingleProjectSpec {
+
+    @Override
+    boolean includeKoverPlugin() {
+        return true
+    }
+
+    def "should publish coverage results to server"() {
+        given:
+        buildFile << """
+            projektor {
+                serverUrl = '${serverUrl}'
+            }
+        """.stripIndent()
+
+        String publicId = "COV123"
+        resultsStubber.stubResultsPostSuccess(publicId)
+
+        File sourceDir = createSourceDirectory(projectRootDir)
+        File testDir = createTestDirectory(projectRootDir)
+
+        writeSourceCodeFile(sourceDir)
+        writePartialCoverageSpecFile(testDir, "PartialSpec")
+
+        when:
+        def result = runSuccessfulBuildInCI('test', 'koverXmlReport', '-i')
+
+        then:
+        result.task(":test").outcome == SUCCESS
+        result.task(":koverXmlReport").outcome == SUCCESS
+
+        and:
+        List<GroupedResults> resultsRequestBodies = resultsStubber.findResultsRequestBodies()
+        resultsRequestBodies.size() == 1
+
+        List<CoverageFilePayload> coverageFilePayloads = resultsRequestBodies[0].coverageFiles
+        coverageFilePayloads.size() == 1
+
+        coverageFilePayloads[0].reportContents.contains("MyClass")
+    }
+
+    def "when coverage disabled should not publish coverage results to server"() {
+        given:
+        buildFile << """
+            projektor {
+                serverUrl = '${serverUrl}'
+                codeCoveragePublish = false
+            }
+        """.stripIndent()
+
+        String publicId = "COV123"
+        resultsStubber.stubResultsPostSuccess(publicId)
+
+        File sourceDir = createSourceDirectory(projectRootDir)
+        File testDir = createTestDirectory(projectRootDir)
+
+        writeSourceCodeFile(sourceDir)
+        writePartialCoverageSpecFile(testDir, "PartialSpec")
+
+        when:
+        def result = runSuccessfulBuildInCI('test', 'koverXmlReport', '-i')
+
+        then:
+        result.task(":test").outcome == SUCCESS
+        result.task(":koverXmlReport").outcome == SUCCESS
+
+        and:
+        List<GroupedResults> resultsRequestBodies = resultsStubber.findResultsRequestBodies()
+        resultsRequestBodies.size() == 1
+
+        List<CoverageFilePayload> coverageFilePayloads = resultsRequestBodies[0].coverageFiles
+        coverageFilePayloads.size() == 0
+    }
+
+    def "can execute 'tasks' task without failing"() {
+        given:
+        buildFile << """
+            projektor {
+                serverUrl = '${serverUrl}'
+            }
+        """.stripIndent()
+
+        File sourceDir = createSourceDirectory(projectRootDir)
+        File testDir = createTestDirectory(projectRootDir)
+
+        writeSourceCodeFile(sourceDir)
+        writePartialCoverageSpecFile(testDir, "PartialSpec")
+
+        when:
+        def result = runSuccessfulBuildInCI('tasks')
+
+        then:
+        result.task(":tasks").outcome == SUCCESS
+    }
+}

--- a/publishers/gradle-plugin/src/testFixtures/groovy/projektor/plugin/BuildFileWriter.groovy
+++ b/publishers/gradle-plugin/src/testFixtures/groovy/projektor/plugin/BuildFileWriter.groovy
@@ -7,6 +7,7 @@ class BuildFileWriter {
             TemporaryFolder projectDir,
             boolean includeProjektorPlugin = true,
             boolean includeJacocoPlugin = false,
+            boolean includeKoverPlugin = false,
             boolean includeCodeNarcPlugin = false
     ) {
         File buildFile = projectDir.newFile('build.gradle')
@@ -15,6 +16,7 @@ class BuildFileWriter {
                 buildFile,
                 includeProjektorPlugin,
                 includeJacocoPlugin,
+                includeKoverPlugin,
                 includeCodeNarcPlugin
         )
 
@@ -25,6 +27,7 @@ class BuildFileWriter {
             File buildFile,
             boolean includeProjektorPlugin = true,
             boolean includeJacocoPlugin = false,
+            boolean includeKoverPlugin = false,
             boolean includeCodeNarcPlugin = false
     ) {
         buildFile << """
@@ -38,6 +41,7 @@ class BuildFileWriter {
                 id 'groovy'
                 ${includeProjektorPlugin ? "id 'dev.projektor.publish'" : ""}
                 ${includeJacocoPlugin ? "id 'jacoco'" : ""}
+                ${includeKoverPlugin ? "id 'org.jetbrains.kotlinx.kover' version '0.4.4'" : ""}
                 ${includeCodeNarcPlugin ? "id 'codenarc'" : ""}
             }
             
@@ -52,6 +56,9 @@ class BuildFileWriter {
             }
 
             ${includeJacocoPlugin ? "jacocoTestReport { dependsOn test }": ""}
+            
+            ${includeKoverPlugin ? "test { kover { enabled = true } }": ""}
+            ${includeKoverPlugin ? "kover { coverageEngine.set(kotlinx.kover.api.CoverageEngine.JACOCO) }": ""}
 
             ${includeCodeNarcPlugin ? "codenarc { reportFormat 'text' }": ""}
         """.stripIndent()


### PR DESCRIPTION
![Screen Shot 2021-12-06 at 3 27 12 PM](https://user-images.githubusercontent.com/2607892/144917426-cf210f60-f737-443f-b56c-8e2162adc6ce.png)

Due to how the test project is setup, I didn't see a better way to make it into a spock `@Unroll`able test.
I ended up duplicating the tests for kover support. 