### PR TITLE
Log of Slack message file write, refactor

### DIFF
--- a/publishers/node-script/src/slack.js
+++ b/publishers/node-script/src/slack.js
@@ -1,20 +1,26 @@
 const fs = require("fs");
 
+function writeFileWithData(
+  fileName,
+  data
+) {
+  console.log("Writing Slack message data to " + fileName);
+  fs.writeFileSync(fileName, data);
+}
+
 function writeSlackMessageFileToDisk(
   reportUrl,
   slackMessageFileName,
   projectName,
   testsFailed
 ) {
-  const fs = require("fs");
-
   const messageJson = createSlackMessageJson(
     reportUrl,
     projectName,
     testsFailed
   );
 
-  fs.writeFileSync(slackMessageFileName, messageJson);
+  writeFileWithData(slackMessageFileName, messageJson);
 }
 
 function createSlackMessageJson(
@@ -51,11 +57,9 @@ function writeNoResultsSlackMessageFileToDisk(
   slackMessageFileName,
   projectName
 ) {
-  const fs = require("fs");
-
   const messageJson = createNoResultsSlackMessageJson(projectName);
 
-  fs.writeFileSync(slackMessageFileName, messageJson);
+  writeFileWithData(slackMessageFileName, messageJson);
 }
 
 function createNoResultsSlackMessageJson(projectName, currentTimestamp) {


### PR DESCRIPTION
This extracts file writing to a common function and removes the duplicated import of fs.

Really, I wanted log output to show that the Slack message file was being written and to what file it was being written.

Warning: I made this edit in GitHub so all bets are off on style and local testing.