### PR TITLE
fix: Sort test results by duration

### DIFF
--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -11,3 +11,5 @@ jestResults/
 test-results/
 
 /coverage/
+
+.env.local

--- a/ui/README.md
+++ b/ui/README.md
@@ -18,6 +18,11 @@ This will start the server on `http://localhost:1234`
 By default, when running locally the API backend points to `http://localhost:8080`
 which is the default port of the server. Start up the server separately using Gradle.
 
+You can point to an alternative API backend by creating an `.env.local` file looking like:
+```
+API_BASE_URL=https://projektor.my.company.com/
+```
+
 ## Testing
 
 The UI is tested by a combination of React Testing Library unit tests

--- a/ui/src/TestSuite/TestSuiteList.tsx
+++ b/ui/src/TestSuite/TestSuiteList.tsx
@@ -79,7 +79,9 @@ const TestSuiteList = ({ publicId, testSuites }: TestSuiteListProps) => {
           },
           { title: "Passed", field: "passed", cellStyle, headerStyle },
           { title: "Failed", field: "failed", cellStyle, headerStyle },
-          { title: "Duration", field: "duration", cellStyle, headerStyle },
+          { title: "Duration", field: "duration", render: (rowData) => (
+              <>{rowData.duration}s</>
+            ), cellStyle, headerStyle },
         ]}
         data={testSuites.map((testSuite) => ({
           fileName: testSuite.fileName,
@@ -87,7 +89,7 @@ const TestSuiteList = ({ publicId, testSuites }: TestSuiteListProps) => {
           group: testSuite.groupName || "",
           passed: testSuite.passingCount,
           failed: testSuite.failureCount,
-          duration: `${testSuite.duration}s`,
+          duration: testSuite.duration,
           idx: testSuite.idx,
         }))}
       />


### PR DESCRIPTION
The "All Tests" page allows you to sort tests by duration, but is currently sorting as a string, .e.g "8.01s is greater than 30.00s because 8 > 3".